### PR TITLE
Fix key description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ mix run --no-halt
 - `i` to install a version
 - `u` to uninstall a version
 - `L` to set a local version
-- `G` to set a local version
+- `G` to set a global version
 
 ## License
 


### PR DESCRIPTION
Just a small fix, since `G` sets a global version and not a local version.