### PR TITLE
"Show all" toggle

### DIFF
--- a/lib/lazyasdf/app.ex
+++ b/lib/lazyasdf/app.ex
@@ -14,7 +14,7 @@ defmodule Lazyasdf.App do
   @arrow_right key(:arrow_right)
 
   defmodule Model do
-    defstruct [:height, :width, :plugins, :versions, :info, selected_pane: :plugins]
+    defstruct [:height, :width, :plugins, :versions, :info, selected_pane: :plugins, only_installed: true]
   end
 
   alias __MODULE__.Model
@@ -28,7 +28,6 @@ defmodule Lazyasdf.App do
     {%Model{
        height: h,
        width: w,
-       selected_pane: :plugins,
        plugins: plugin_state,
        versions: version_state,
        info: info_state
@@ -45,6 +44,9 @@ defmodule Lazyasdf.App do
 
         {_, {:event, %{ch: ch, key: key}}} when ch == ?l or key == @arrow_right ->
           put_in(model.selected_pane, :versions)
+
+        {_, {:event, %{ch: ?a}}} ->
+          put_in(model.only_installed, !model.only_installed)
 
         {_, {{:refresh, plugin}, versions}} ->
           put_in(model.versions[plugin].items, versions)
@@ -100,12 +102,14 @@ defmodule Lazyasdf.App do
     new_model
   end
 
-  defp space(), do: text(content: " ")
+  defp space(), do: text(content: " | ")
 
-  defp help_bar(%{selected_pane: :versions} = _model) do
+  defp help_bar(%{selected_pane: :versions} = model) do
     bar do
       label do
         text(content: "[h/j/k/l] movement")
+        space()
+        text(content: if(model.only_installed, do: "show [a]ll", else: "show only inst[a]lled"))
         space()
         text(content: "[i]nstall")
         space()
@@ -120,10 +124,12 @@ defmodule Lazyasdf.App do
     end
   end
 
-  defp help_bar(_model) do
+  defp help_bar(model) do
     bar do
       label do
         text(content: "[h/j/k/l] movement")
+        space()
+        text(content: if(model.only_installed, do: "show [a]ll", else: "show only inst[a]lled"))
         space()
         text(content: "[q]uit")
       end

--- a/lib/lazyasdf/app.ex
+++ b/lib/lazyasdf/app.ex
@@ -87,7 +87,7 @@ defmodule Lazyasdf.App do
           end
 
         {:versions, msg} ->
-          case Versions.update(Plugins.selected(model.plugins), model.versions, msg) do
+          case Versions.update(Plugins.selected(model.plugins), model.versions, model.only_installed, msg) do
             {vmodel, command} ->
               {put_in(model.versions, vmodel), command}
 

--- a/lib/lazyasdf/app.ex
+++ b/lib/lazyasdf/app.ex
@@ -97,7 +97,7 @@ defmodule Lazyasdf.App do
 
   defp space(), do: text(content: " ")
 
-  defp help_bar(_model) do
+  defp help_bar(%{selected_pane: :versions} = _model) do
     bar do
       label do
         text(content: "[h/j/k/l] movement")
@@ -109,6 +109,18 @@ defmodule Lazyasdf.App do
         text(content: "set [L]ocal")
         space()
         text(content: "set [G]lobal")
+        space()
+        text(content: "[q]uit")
+      end
+    end
+  end
+
+  defp help_bar(_model) do
+    bar do
+      label do
+        text(content: "[h/j/k/l] movement")
+        space()
+        text(content: "[q]uit")
       end
     end
   end

--- a/lib/lazyasdf/pane/versions.ex
+++ b/lib/lazyasdf/pane/versions.ex
@@ -142,7 +142,7 @@ defmodule Lazyasdf.Pane.Versions do
     Enum.at(model.list, model.cursor_y)
   end
 
-  def render(selected, model, %{height: height} = global_model) do
+  def render(selected, model, %{height: height, only_installed: only_installed} = global_model) do
     selected_model = model[selected_plugin(global_model.plugins)]
 
     panel title:
@@ -150,7 +150,7 @@ defmodule Lazyasdf.Pane.Versions do
               " (#{install_count(model, global_model)}/#{version_count(model, global_model)})",
           height: :fill do
       for {version, idx} <-
-            selected_model.items
+            if(only_installed, do: selected_model.installed, else: selected_model.items)
             |> Enum.drop(selected_model.y_offset)
             |> Enum.take(height - 3)
             |> Enum.with_index do

--- a/lib/lazyasdf/pane/versions.ex
+++ b/lib/lazyasdf/pane/versions.ex
@@ -6,7 +6,6 @@ defmodule Lazyasdf.Pane.Versions do
 
   alias Lazyasdf.Window
   alias Lazyasdf.Asdf
-  alias Lazyasdf.Pane.Plugins
 
   @arrow_up key(:arrow_up)
   @arrow_down key(:arrow_down)
@@ -17,12 +16,6 @@ defmodule Lazyasdf.Pane.Versions do
   ]
 
   def init(plugins) do
-    version_commands =
-      for p <- plugins, do: Command.new(fn -> Asdf.list_all(p) end, {:refresh, p})
-
-    installed_commands =
-      for p <- plugins, do: Command.new(fn -> Asdf.list(p) end, {:installed, p})
-
     {Map.new(plugins, fn p ->
        {p,
         %{
@@ -35,7 +28,7 @@ defmodule Lazyasdf.Pane.Versions do
           globaling: [],
           uninstalling: []
         }}
-     end), version_commands ++ installed_commands}
+     end), []}
   end
 
   def update(plugin, model, msg) do
@@ -138,18 +131,22 @@ defmodule Lazyasdf.Pane.Versions do
   end
 
   defp version_count(model, global_model) do
-    length(model[Plugins.selected(global_model.plugins)].items)
+    length(model[selected_plugin(global_model.plugins)].items)
   end
 
   defp install_count(model, global_model) do
-    length(model[Plugins.selected(global_model.plugins)].installed)
+    length(model[selected_plugin(global_model.plugins)].installed)
+  end
+
+  def selected_plugin(model) do
+    Enum.at(model.list, model.cursor_y)
   end
 
   def render(selected, model, %{height: height} = global_model) do
-    selected_model = model[Plugins.selected(global_model.plugins)]
+    selected_model = model[selected_plugin(global_model.plugins)]
 
     panel title:
-            Plugins.selected(global_model.plugins) <>
+            selected_plugin(global_model.plugins) <>
               " (#{install_count(model, global_model)}/#{version_count(model, global_model)})",
           height: :fill do
       for {version, idx} <-


### PR DESCRIPTION
Hi. Most of the time I don't want to install new versions for the tools, but change the current version in the local folder or globally. Unfortunately some of the tools has a huge list of available versions (e.g.: 423 for elixir and that not the longest list) and I need to scroll down for ages to find my installed versions. My PR tries to solve this issue, I've added a toggle to show only installed versions / all versions for the selected plugin. I also changed loading the versions to be lazy-loaded as we don't really need everything on startup and changed the bottom bar to be a bit more context-aware.